### PR TITLE
restructures nav markup for better styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,20 +15,20 @@ html {
 nav {
     display: flex; 
     justify-content: space-between;
-    align-items: flex-end;
+    align-items: center;
     padding: .5em;
     background-color: darkslategray;
     
 }
-nav div {
+.logo-links {
     flex: 1;
     font-size: 2.4em;
     font-family: 'Roboto Condensed', sans-serif;
 }
-nav a{
+.nav-links a {
     margin-right: 4em;
 }
-nav a:last-of-type {
+.nav-links a:last-of-type {
     margin-right: .5em;
 }
 nav img{

--- a/index.html
+++ b/index.html
@@ -11,16 +11,18 @@
 </head>
 <body>
     <nav>
-        <div> 
+        <div class="logo-links"> 
             <p>
                 <a class="logo" href="https://kinggizzardandthelizardwizard.com/bootlegger">
                     <img alt="bootlegger logo" src="media/img/bootleg.png"></a>
                 KGLW Live Show Bootlegger Archive
             </p>
         </div>
-        <a class="link" href="">Omaha '24</a>
-        <a class="linka" href="index.html">Red Rocks '24</a>
-        <a class="link" href="">Oregon '24</a>
+        <div class="nav-links">
+            <a class="link" href="">Omaha '24</a>
+            <a class="linka" href="index.html">Red Rocks '24</a>
+            <a class="link" href="">Oregon '24</a>
+        </div>
     </nav>
     <section>
 


### PR DESCRIPTION
## In index.html
1. adds a new div inside the nav element to wrap the right side links. Now there are two flex children (both divs) inside the nav element, which is serving as a flex container.
2. Adds class names to both of the divs in the nav element so they can be styled separately.

## In style.css
3. changing align-items on the nav from flex-end to center will vertically align the flex children by centering them along the cross-axis of the flex container.
4. Adding class selectors (.logo-links and .nav-links) instead of generic element selectors (div and a) allows the ability to target different parts of the nav with more specificity.